### PR TITLE
Supress lands in random cards

### DIFF
--- a/controllers/cardsController.js
+++ b/controllers/cardsController.js
@@ -123,7 +123,7 @@ module.exports = {
             return cards.getRandomCard()
         })
         .then(function(results) {
-            for (var j = 1; j < results.length; j++) {
+            for (var j = 0; j < results.length; j++) {
                 results[j] = ` ${results[j]}`
             }
             results = String(results)

--- a/models/cards.js
+++ b/models/cards.js
@@ -5,6 +5,12 @@ module.exports = {
     return axios.get(`https://api.scryfall.com/cards/random`)
       .then(response => {
         response = `[${response.data.name}]`;
+        const landList = ['[Mountain]', '[Island]', '[Plains]', '[Swamp]', '[Forest]', '[Wastes]', '[object Promise]' ]
+        while( landList.indexOf(response) != -1 ){
+                            console.log("Mana type %s found. Requesting new random card.", response)
+                            response = this.getRandomCard();
+                    }
+                    console.log("Card %s found.", response)
         return response;
       })
   },

--- a/models/cards.js
+++ b/models/cards.js
@@ -6,7 +6,7 @@ module.exports = {
       .then(response => {
         response = `[${response.data.name}]`;
         const landList = ['[Mountain]', '[Island]', '[Plains]', '[Swamp]', '[Forest]', '[Wastes]', '[object Promise]' ]
-        while( landList.indexOf(response) != -1 ){
+        if( landList.indexOf(response) != -1 ){
                             console.log("Mana type %s found. Requesting new random card.", response)
                             response = this.getRandomCard();
                     }


### PR DESCRIPTION
Fixes #8 

To test, you can request random card repeatedly. There is a `console.log` in place that will show you want cards the app receives and will bring your attention to when a land was detected and request a new card.

I think the Promise completion is working with how I wrote the check.  The worst possible scenario just occurred for me, locally, and I believe it shows that the suppression is working.
```
Mana type [Forest] found. Requesting new random card.
Card [object Promise] found.
Mana type [Swamp] found. Requesting new random card.
Card [object Promise] found.
Mana type [Plains] found. Requesting new random card.
Card [object Promise] found.
Card [Coral Helm] found.
Card [Primal Surge] found.
Card [Theft of Dreams] found.
Card [Proven Combatant Token] found.
Card [Rockcaster Platoon] found.
```
I'd prefer that the logs under each `Mana type <type> found...` line didn't display `object Promise`, but it looks like when the `.then()` method is called in the recursed instances of the request, the check is performed again and successive lands are caught.